### PR TITLE
Fix build for Haiku

### DIFF
--- a/src/makefile
+++ b/src/makefile
@@ -79,7 +79,7 @@ endif
 # Haiku
 ifeq ($(PLATFORM),haiku)
 LFLAGS += `sdl-config --libs` -lGL -lSDL_mixer
-CFLAGS += `sdl-config --cflags`
+CFLAGS += `sdl-config --cflags` -DNO_SDL_GLEXT
 endif
 
 # Pandora


### PR DESCRIPTION
Haiku provides a glext.h which conflicts with the SDL one.
